### PR TITLE
User enroll

### DIFF
--- a/Example/PerseDemo/PerseDemo.xcodeproj/project.pbxproj
+++ b/Example/PerseDemo/PerseDemo.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0BCB86084333FA5413782255 /* libPods-PerseDemoTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 73D29A424BBE7CCBA0A5C2B5 /* libPods-PerseDemoTests.a */; };
+		5607017B91207F0E0D0D4CE9 /* libPods-PerseDemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A1B2A8C6A6E8EADA1C2CEA30 /* libPods-PerseDemo.a */; };
 		5C06E54825D1F09A00E6770F /* Podfile in Resources */ = {isa = PBXBuildFile; fileRef = 5C06E54725D1F09A00E6770F /* Podfile */; };
 		5C0D7B592656C9CB00A24232 /* human2.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 5C0D7B572656C9CB00A24232 /* human2.jpeg */; };
 		5C0D7B5A2656C9CB00A24232 /* human.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 5C0D7B582656C9CB00A24232 /* human.jpeg */; };
@@ -15,24 +15,25 @@
 		5C29525426543179008E35F7 /* dog.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 5C29525326543179008E35F7 /* dog.jpeg */; };
 		5C29527E26543FEB008E35F7 /* FileUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C29527D26543FEB008E35F7 /* FileUtils.swift */; };
 		5C29528226544A7B008E35F7 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C29528126544A7B008E35F7 /* Environment.swift */; };
-		5C38E9FE265D5CB500922B91 /* PerseFaceDetectWithDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C38E9FD265D5CB500922B91 /* PerseFaceDetectWithDataTests.swift */; };
+		5C38E9FE265D5CB500922B91 /* FaceDetectWithDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C38E9FD265D5CB500922B91 /* FaceDetectWithDataTests.swift */; };
 		5C38EA06265D601B00922B91 /* DataUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C38EA05265D601B00922B91 /* DataUtils.swift */; };
-		5C38EA12265D69C300922B91 /* PerseFaceCompareWithDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C38EA11265D69C300922B91 /* PerseFaceCompareWithDataTests.swift */; };
+		5C38EA12265D69C300922B91 /* FaceCompareWithDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C38EA11265D69C300922B91 /* FaceCompareWithDataTests.swift */; };
 		5C41242926554C8C00C02049 /* PerseUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C41242826554C8C00C02049 /* PerseUtils.swift */; };
-		5C412453265594DA00C02049 /* PerseFaceCompareWithFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C412452265594DA00C02049 /* PerseFaceCompareWithFileTests.swift */; };
+		5C412453265594DA00C02049 /* FaceCompareWithFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C412452265594DA00C02049 /* FaceCompareWithFileTests.swift */; };
 		5C73AAD52681184E0028435B /* PerseCameraViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C73AAD42681184E0028435B /* PerseCameraViewController.swift */; };
 		5CB416AB2652F08E00B7D1EC /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB416AA2652F08E00B7D1EC /* Environment.swift */; };
+		5CD60F1126D80D6400F4D995 /* FaceEnrollmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD60F1026D80D6300F4D995 /* FaceEnrollmentTests.swift */; };
 		5CE123D8264AF36600D484A1 /* FileUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE123D7264AF36600D484A1 /* FileUtils.swift */; };
 		5CE123ED264B087800D484A1 /* PerseCompareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE123EC264B087800D484A1 /* PerseCompareViewController.swift */; };
 		5CE1241C264C0F4E00D484A1 /* TableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE1241B264C0F4E00D484A1 /* TableCell.swift */; };
-		5CF64E722653F546004763E3 /* PerseFaceDetectWithFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF64E712653F546004763E3 /* PerseFaceDetectWithFileTests.swift */; };
+		5CF64E722653F546004763E3 /* FaceDetectWithFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF64E712653F546004763E3 /* FaceDetectWithFileTests.swift */; };
 		6176EFC2252E496D00F4D4DD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6176EFC1252E496D00F4D4DD /* AppDelegate.swift */; };
 		6176EFC4252E496D00F4D4DD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6176EFC3252E496D00F4D4DD /* SceneDelegate.swift */; };
 		6176EFC9252E496D00F4D4DD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6176EFC7252E496D00F4D4DD /* Main.storyboard */; };
 		6176EFCB252E496F00F4D4DD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6176EFCA252E496F00F4D4DD /* Assets.xcassets */; };
 		6176EFCE252E496F00F4D4DD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6176EFCC252E496F00F4D4DD /* LaunchScreen.storyboard */; };
 		6176EFDE252E4A9100F4D4DD /* PerseDetectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6176EFDB252E4A9100F4D4DD /* PerseDetectViewController.swift */; };
-		E09979052B946FDEE970C19E /* libPods-PerseDemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBB97A643E3B066971AFBEC /* libPods-PerseDemo.a */; };
+		EC95A61D74ECD7D73BEE49F7 /* libPods-PerseDemoTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E8D70F5EB03490C1A53E5B9 /* libPods-PerseDemoTests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,9 +47,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1CBB97A643E3B066971AFBEC /* libPods-PerseDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PerseDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		385AE6EC5ECF668DA435EF9C /* Pods-PerseDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PerseDemo.release.xcconfig"; path = "Target Support Files/Pods-PerseDemo/Pods-PerseDemo.release.xcconfig"; sourceTree = "<group>"; };
-		4A1E8197F858A9CA5D2B3EC5 /* Pods-PerseDemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PerseDemoTests.release.xcconfig"; path = "Target Support Files/Pods-PerseDemoTests/Pods-PerseDemoTests.release.xcconfig"; sourceTree = "<group>"; };
 		5C06E54725D1F09A00E6770F /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; };
 		5C06E5A925D1FBC500E6770F /* Perse.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Perse.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5C0D7B572656C9CB00A24232 /* human2.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = human2.jpeg; sourceTree = "<group>"; };
@@ -57,20 +55,22 @@
 		5C29525326543179008E35F7 /* dog.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = dog.jpeg; sourceTree = "<group>"; };
 		5C29527D26543FEB008E35F7 /* FileUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUtils.swift; sourceTree = "<group>"; };
 		5C29528126544A7B008E35F7 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
-		5C38E9FD265D5CB500922B91 /* PerseFaceDetectWithDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerseFaceDetectWithDataTests.swift; sourceTree = "<group>"; };
+		5C38E9FD265D5CB500922B91 /* FaceDetectWithDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaceDetectWithDataTests.swift; sourceTree = "<group>"; };
 		5C38EA05265D601B00922B91 /* DataUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataUtils.swift; sourceTree = "<group>"; };
-		5C38EA11265D69C300922B91 /* PerseFaceCompareWithDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerseFaceCompareWithDataTests.swift; sourceTree = "<group>"; };
+		5C38EA11265D69C300922B91 /* FaceCompareWithDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaceCompareWithDataTests.swift; sourceTree = "<group>"; };
 		5C41242826554C8C00C02049 /* PerseUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerseUtils.swift; sourceTree = "<group>"; };
-		5C412452265594DA00C02049 /* PerseFaceCompareWithFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerseFaceCompareWithFileTests.swift; sourceTree = "<group>"; };
+		5C412452265594DA00C02049 /* FaceCompareWithFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaceCompareWithFileTests.swift; sourceTree = "<group>"; };
 		5C73AAD42681184E0028435B /* PerseCameraViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerseCameraViewController.swift; sourceTree = "<group>"; };
 		5C97A92A26CAE6CF00068625 /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
 		5CB416AA2652F08E00B7D1EC /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
+		5CD60F1026D80D6300F4D995 /* FaceEnrollmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaceEnrollmentTests.swift; sourceTree = "<group>"; };
 		5CE123D7264AF36600D484A1 /* FileUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileUtils.swift; sourceTree = "<group>"; };
 		5CE123EC264B087800D484A1 /* PerseCompareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerseCompareViewController.swift; sourceTree = "<group>"; };
 		5CE1241B264C0F4E00D484A1 /* TableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableCell.swift; sourceTree = "<group>"; };
 		5CF64E672653F51F004763E3 /* PerseDemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PerseDemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		5CF64E712653F546004763E3 /* PerseFaceDetectWithFileTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerseFaceDetectWithFileTests.swift; sourceTree = "<group>"; };
+		5CF64E712653F546004763E3 /* FaceDetectWithFileTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FaceDetectWithFileTests.swift; sourceTree = "<group>"; };
 		5CF64E732653F555004763E3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5E8D70F5EB03490C1A53E5B9 /* libPods-PerseDemoTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PerseDemoTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6176EFBE252E496D00F4D4DD /* PerseDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PerseDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6176EFC1252E496D00F4D4DD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6176EFC3252E496D00F4D4DD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -79,9 +79,11 @@
 		6176EFCD252E496F00F4D4DD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		6176EFCF252E496F00F4D4DD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6176EFDB252E4A9100F4D4DD /* PerseDetectViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerseDetectViewController.swift; sourceTree = "<group>"; };
-		73D29A424BBE7CCBA0A5C2B5 /* libPods-PerseDemoTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PerseDemoTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8CD26D500117CC19394F1CA9 /* Pods-PerseDemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PerseDemoTests.debug.xcconfig"; path = "Target Support Files/Pods-PerseDemoTests/Pods-PerseDemoTests.debug.xcconfig"; sourceTree = "<group>"; };
-		A18ABC2DA27AF94BFF4175F3 /* Pods-PerseDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PerseDemo.debug.xcconfig"; path = "Target Support Files/Pods-PerseDemo/Pods-PerseDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		A1B2A8C6A6E8EADA1C2CEA30 /* libPods-PerseDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PerseDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A66503A74A8AF4532EB87C4C /* Pods-PerseDemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PerseDemoTests.debug.xcconfig"; path = "Target Support Files/Pods-PerseDemoTests/Pods-PerseDemoTests.debug.xcconfig"; sourceTree = "<group>"; };
+		BD1C3C91F0EE71FDD07657C4 /* Pods-PerseDemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PerseDemoTests.release.xcconfig"; path = "Target Support Files/Pods-PerseDemoTests/Pods-PerseDemoTests.release.xcconfig"; sourceTree = "<group>"; };
+		D35375D43E27A39E1BF69A7B /* Pods-PerseDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PerseDemo.release.xcconfig"; path = "Target Support Files/Pods-PerseDemo/Pods-PerseDemo.release.xcconfig"; sourceTree = "<group>"; };
+		D91A3BFDC6EF6F1B7638B3D1 /* Pods-PerseDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PerseDemo.debug.xcconfig"; path = "Target Support Files/Pods-PerseDemo/Pods-PerseDemo.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -89,7 +91,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0BCB86084333FA5413782255 /* libPods-PerseDemoTests.a in Frameworks */,
+				EC95A61D74ECD7D73BEE49F7 /* libPods-PerseDemoTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -97,7 +99,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E09979052B946FDEE970C19E /* libPods-PerseDemo.a in Frameworks */,
+				5607017B91207F0E0D0D4CE9 /* libPods-PerseDemo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -120,14 +122,15 @@
 			children = (
 				5CF64E732653F555004763E3 /* Info.plist */,
 				5C2952522654316E008E35F7 /* Assets */,
-				5C412452265594DA00C02049 /* PerseFaceCompareWithFileTests.swift */,
-				5C38EA11265D69C300922B91 /* PerseFaceCompareWithDataTests.swift */,
+				5C412452265594DA00C02049 /* FaceCompareWithFileTests.swift */,
+				5C38EA11265D69C300922B91 /* FaceCompareWithDataTests.swift */,
 				5C41242826554C8C00C02049 /* PerseUtils.swift */,
 				5C29527D26543FEB008E35F7 /* FileUtils.swift */,
 				5C29528126544A7B008E35F7 /* Environment.swift */,
-				5C38E9FD265D5CB500922B91 /* PerseFaceDetectWithDataTests.swift */,
-				5CF64E712653F546004763E3 /* PerseFaceDetectWithFileTests.swift */,
+				5C38E9FD265D5CB500922B91 /* FaceDetectWithDataTests.swift */,
+				5CF64E712653F546004763E3 /* FaceDetectWithFileTests.swift */,
 				5C38EA05265D601B00922B91 /* DataUtils.swift */,
+				5CD60F1026D80D6300F4D995 /* FaceEnrollmentTests.swift */,
 			);
 			path = PerseDemoTests;
 			sourceTree = "<group>";
@@ -176,10 +179,10 @@
 		E43515AC47E0279330A1606A /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				A18ABC2DA27AF94BFF4175F3 /* Pods-PerseDemo.debug.xcconfig */,
-				385AE6EC5ECF668DA435EF9C /* Pods-PerseDemo.release.xcconfig */,
-				8CD26D500117CC19394F1CA9 /* Pods-PerseDemoTests.debug.xcconfig */,
-				4A1E8197F858A9CA5D2B3EC5 /* Pods-PerseDemoTests.release.xcconfig */,
+				D91A3BFDC6EF6F1B7638B3D1 /* Pods-PerseDemo.debug.xcconfig */,
+				D35375D43E27A39E1BF69A7B /* Pods-PerseDemo.release.xcconfig */,
+				A66503A74A8AF4532EB87C4C /* Pods-PerseDemoTests.debug.xcconfig */,
+				BD1C3C91F0EE71FDD07657C4 /* Pods-PerseDemoTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -188,8 +191,8 @@
 			isa = PBXGroup;
 			children = (
 				5C06E5A925D1FBC500E6770F /* Perse.framework */,
-				1CBB97A643E3B066971AFBEC /* libPods-PerseDemo.a */,
-				73D29A424BBE7CCBA0A5C2B5 /* libPods-PerseDemoTests.a */,
+				A1B2A8C6A6E8EADA1C2CEA30 /* libPods-PerseDemo.a */,
+				5E8D70F5EB03490C1A53E5B9 /* libPods-PerseDemoTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -201,11 +204,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5CF64E702653F51F004763E3 /* Build configuration list for PBXNativeTarget "PerseDemoTests" */;
 			buildPhases = (
-				528F8B536844877A653375ED /* [CP] Check Pods Manifest.lock */,
+				2652B4E1CF16B4C0C402BF78 /* [CP] Check Pods Manifest.lock */,
 				5CF64E632653F51F004763E3 /* Sources */,
 				5CF64E642653F51F004763E3 /* Frameworks */,
 				5CF64E652653F51F004763E3 /* Resources */,
-				A47D6E1DCE23CA5409969DB3 /* [CP] Copy Pods Resources */,
+				B9E24005BCA1E8B2781C00D4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -221,11 +224,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6176EFD2252E496F00F4D4DD /* Build configuration list for PBXNativeTarget "PerseDemo" */;
 			buildPhases = (
-				594C9117A0C58E067B175EF8 /* [CP] Check Pods Manifest.lock */,
+				D731D9262804690AE6BA3C41 /* [CP] Check Pods Manifest.lock */,
 				6176EFBA252E496D00F4D4DD /* Sources */,
 				6176EFBB252E496D00F4D4DD /* Frameworks */,
 				6176EFBC252E496D00F4D4DD /* Resources */,
-				DA67A1B50B0019AE4A256998 /* [CP] Copy Pods Resources */,
+				204713C8450333812368F684 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -299,7 +302,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		528F8B536844877A653375ED /* [CP] Check Pods Manifest.lock */ = {
+		204713C8450333812368F684 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PerseDemo/Pods-PerseDemo-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PerseDemo/Pods-PerseDemo-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PerseDemo/Pods-PerseDemo-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2652B4E1CF16B4C0C402BF78 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -321,7 +341,24 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		594C9117A0C58E067B175EF8 /* [CP] Check Pods Manifest.lock */ = {
+		B9E24005BCA1E8B2781C00D4 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PerseDemoTests/Pods-PerseDemoTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PerseDemoTests/Pods-PerseDemoTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PerseDemoTests/Pods-PerseDemoTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D731D9262804690AE6BA3C41 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -343,40 +380,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A47D6E1DCE23CA5409969DB3 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-PerseDemoTests/Pods-PerseDemoTests-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-PerseDemoTests/Pods-PerseDemoTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PerseDemoTests/Pods-PerseDemoTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		DA67A1B50B0019AE4A256998 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-PerseDemo/Pods-PerseDemo-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-PerseDemo/Pods-PerseDemo-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PerseDemo/Pods-PerseDemo-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -384,13 +387,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5CF64E722653F546004763E3 /* PerseFaceDetectWithFileTests.swift in Sources */,
-				5C38E9FE265D5CB500922B91 /* PerseFaceDetectWithDataTests.swift in Sources */,
+				5CF64E722653F546004763E3 /* FaceDetectWithFileTests.swift in Sources */,
+				5C38E9FE265D5CB500922B91 /* FaceDetectWithDataTests.swift in Sources */,
 				5C29528226544A7B008E35F7 /* Environment.swift in Sources */,
 				5C38EA06265D601B00922B91 /* DataUtils.swift in Sources */,
-				5C38EA12265D69C300922B91 /* PerseFaceCompareWithDataTests.swift in Sources */,
+				5C38EA12265D69C300922B91 /* FaceCompareWithDataTests.swift in Sources */,
 				5C29527E26543FEB008E35F7 /* FileUtils.swift in Sources */,
-				5C412453265594DA00C02049 /* PerseFaceCompareWithFileTests.swift in Sources */,
+				5CD60F1126D80D6400F4D995 /* FaceEnrollmentTests.swift in Sources */,
+				5C412453265594DA00C02049 /* FaceCompareWithFileTests.swift in Sources */,
 				5C41242926554C8C00C02049 /* PerseUtils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -442,7 +446,7 @@
 /* Begin XCBuildConfiguration section */
 		5CF64E6E2653F51F004763E3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8CD26D500117CC19394F1CA9 /* Pods-PerseDemoTests.debug.xcconfig */;
+			baseConfigurationReference = A66503A74A8AF4532EB87C4C /* Pods-PerseDemoTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 2B682PKZVS;
@@ -463,7 +467,7 @@
 		};
 		5CF64E6F2653F51F004763E3 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4A1E8197F858A9CA5D2B3EC5 /* Pods-PerseDemoTests.release.xcconfig */;
+			baseConfigurationReference = BD1C3C91F0EE71FDD07657C4 /* Pods-PerseDemoTests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 2B682PKZVS;
@@ -606,7 +610,7 @@
 		};
 		6176EFD3252E496F00F4D4DD /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A18ABC2DA27AF94BFF4175F3 /* Pods-PerseDemo.debug.xcconfig */;
+			baseConfigurationReference = D91A3BFDC6EF6F1B7638B3D1 /* Pods-PerseDemo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -639,7 +643,7 @@
 		};
 		6176EFD4252E496F00F4D4DD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 385AE6EC5ECF668DA435EF9C /* Pods-PerseDemo.release.xcconfig */;
+			baseConfigurationReference = D35375D43E27A39E1BF69A7B /* Pods-PerseDemo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Example/PerseDemo/PerseDemo.xcodeproj/project.pbxproj
+++ b/Example/PerseDemo/PerseDemo.xcodeproj/project.pbxproj
@@ -632,7 +632,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.2;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.cyberlabs.persedemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -665,7 +665,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.2;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.cyberlabs.persedemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Example/PerseDemo/PerseDemo/Base.lproj/Main.storyboard
+++ b/Example/PerseDemo/PerseDemo/Base.lproj/Main.storyboard
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="6Ze-hp-caJ">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -12,35 +11,35 @@
         <scene sceneID="npD-1J-q4R">
             <objects>
                 <viewController id="l7p-dQ-FCU" customClass="PerseDetectViewController" customModule="PerseDemo" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="hFs-or-lPB">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                    <view key="view" contentMode="scaleToFill" misplaced="YES" id="hFs-or-lPB">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="02h-mG-BJe">
-                                <rect key="frame" x="87" y="20" width="240" height="240"/>
+                                <rect key="frame" x="87" y="20" width="426" height="240"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                             </imageView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="OiO-zy-iYl">
-                                <rect key="frame" x="0.0" y="325" width="414" height="483"/>
+                                <rect key="frame" x="0.0" y="325" width="600" height="275"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" textLabel="pln-i8-JMF" detailTextLabel="ApB-zF-Wb6" rowHeight="48" style="IBUITableViewCellStyleValue1" id="BI5-dc-zkm">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="48"/>
+                                        <rect key="frame" x="0.0" y="28" width="600" height="48"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="BI5-dc-zkm" id="aFX-Lq-HBO">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="48"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="48"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="pln-i8-JMF">
-                                                    <rect key="frame" x="20" y="14" width="33" height="20.5"/>
+                                                    <rect key="frame" x="16" y="14" width="33" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ApB-zF-Wb6">
-                                                    <rect key="frame" x="350" y="14" width="44" height="20.5"/>
+                                                    <rect key="frame" x="540" y="14" width="44" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -52,7 +51,7 @@
                                 </prototypes>
                             </tableView>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hJJ-Gx-tQW">
-                                <rect key="frame" x="149" y="268" width="116" height="49"/>
+                                <rect key="frame" x="149" y="268" width="302" height="49"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Get Image"/>
                                 <connections>
@@ -136,22 +135,22 @@
         <scene sceneID="fw1-pF-K0V">
             <objects>
                 <viewController id="K7h-4m-K7g" customClass="PerseCompareViewController" customModule="PerseDemo" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="wq8-JE-mlY">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                    <view key="view" contentMode="scaleToFill" misplaced="YES" id="wq8-JE-mlY">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4hl-ma-P0z">
-                                <rect key="frame" x="20" y="20" width="183" height="183"/>
+                                <rect key="frame" x="20" y="20" width="369" height="183"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                             </imageView>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wgz-AP-wnm">
-                                <rect key="frame" x="212" y="20" width="182" height="182"/>
+                                <rect key="frame" x="212" y="20" width="368" height="182"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ceX-G5-JVj">
-                                <rect key="frame" x="53" y="211" width="116" height="49"/>
+                                <rect key="frame" x="53" y="211" width="302" height="49"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Get Image"/>
                                 <connections>
@@ -159,7 +158,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QyM-2a-cBM">
-                                <rect key="frame" x="245" y="211" width="116" height="49"/>
+                                <rect key="frame" x="245" y="211" width="302" height="49"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Get Image"/>
                                 <connections>
@@ -167,7 +166,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nso-N1-Gqz">
-                                <rect key="frame" x="154" y="268" width="106" height="34"/>
+                                <rect key="frame" x="154" y="268" width="292" height="34"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -177,25 +176,25 @@
                                 </connections>
                             </button>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="7mj-PV-TLn">
-                                <rect key="frame" x="0.0" y="310" width="414" height="415"/>
+                                <rect key="frame" x="0.0" y="310" width="600" height="207"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" textLabel="9Y4-E8-IIt" detailTextLabel="JNO-Pq-ZSE" rowHeight="48" style="IBUITableViewCellStyleValue1" id="gJe-a6-Kpi">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="48"/>
+                                        <rect key="frame" x="0.0" y="28" width="600" height="48"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gJe-a6-Kpi" id="ixU-fl-DY9">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="48"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="48"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9Y4-E8-IIt">
-                                                    <rect key="frame" x="20" y="14" width="33" height="20.5"/>
+                                                    <rect key="frame" x="16" y="14" width="33" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="JNO-Pq-ZSE">
-                                                    <rect key="frame" x="350" y="14" width="44" height="20.5"/>
+                                                    <rect key="frame" x="540" y="14" width="44" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -226,17 +225,17 @@
         <scene sceneID="gzy-of-8lf">
             <objects>
                 <viewController id="YOl-mh-QKG" customClass="PerseCameraViewController" customModule="PerseDemo" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="p4F-Wt-NU0">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                    <view key="view" contentMode="scaleToFill" misplaced="YES" id="p4F-Wt-NU0">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="R2Y-bi-PCo" customClass="PerseCamera" customModule="Perse">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tLq-QS-0Xp" customClass="GraphicView" customModule="PerseDemo" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="349"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="141"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Left Eye Open" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JQw-4p-2kM">
@@ -368,7 +367,7 @@
                                 </subviews>
                             </view>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xxV-i1-DII">
-                                <rect key="frame" x="206" y="512" width="200" height="200"/>
+                                <rect key="frame" x="392" y="304" width="200" height="200"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                             </imageView>
                         </subviews>
@@ -379,10 +378,10 @@
                     <connections>
                         <outlet property="faceImageView" destination="xxV-i1-DII" id="4xn-gJ-OdM"/>
                         <outlet property="faceSharpnessIcon" destination="WPu-kS-8TP" id="Qbt-0V-JkN"/>
-                        <outlet property="faceUnderexposeIcon" destination="0Os-tg-VbW" id="0zn-tL-ISD"/>
+                        <outlet property="faceUnderexposureIcon" destination="0Os-tg-VbW" id="0zn-tL-ISD"/>
                         <outlet property="horizontalMovementLabel" destination="Vjh-Tq-NTe" id="gLs-by-UDj"/>
                         <outlet property="imageSharpnessIcon" destination="1MD-M9-0WD" id="uJz-SI-NOv"/>
-                        <outlet property="imageUnderexposeIcon" destination="nPW-mh-2IT" id="xkj-Wh-JCE"/>
+                        <outlet property="imageUnderexposureIcon" destination="nPW-mh-2IT" id="xkj-Wh-JCE"/>
                         <outlet property="leftEyeIcon" destination="JXt-H2-LPQ" id="iQO-X1-Bvx"/>
                         <outlet property="perseCamera" destination="R2Y-bi-PCo" id="gVH-lS-yuN"/>
                         <outlet property="rightEyeIcon" destination="CY9-uo-oyZ" id="CDJ-mn-DmU"/>

--- a/Example/PerseDemo/PerseDemo/Info.plist
+++ b/Example/PerseDemo/PerseDemo/Info.plist
@@ -2,10 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BASE_URL</key>
-	<string>$(BASE_URL)</string>
 	<key>API_KEY</key>
 	<string>$(API_KEY)</string>
+	<key>BASE_URL</key>
+	<string>$(BASE_URL)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -29,7 +29,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Camera usage for Perse</string>
 	<key>NSPerseUsageDescription</key>
-	<string>The face detection&apos;s module for iOS with a lot of awesome features</string>
+	<string>The face detection's module for iOS with a lot of awesome features</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This app requires access to the photo library</string>
 	<key>UIApplicationSceneManifest</key>

--- a/Example/PerseDemo/PerseDemo/PerseCameraViewController.swift
+++ b/Example/PerseDemo/PerseDemo/PerseCameraViewController.swift
@@ -25,8 +25,11 @@ class PerseCameraViewController:
         super.viewDidLoad()
                                            
         self.reset()
-        
-        self.perseCamera.apiKey = Environment.apiKey
+                
+        self.perseCamera.perse = Perse(
+            apiKey: Environment.apiKey,
+            baseUrl: Environment.baseUrl
+        )
         self.perseCamera.perseEventListener = self
         self.perseCamera.startPreview()
         self.perseCamera.setDetectionBox(true)
@@ -37,7 +40,7 @@ class PerseCameraViewController:
         _ count: Int,
         _ total: Int,
         _ imagePath: String,
-        _ detectResponse: DetectResponse?
+        _ detectResponse: PerseAPIResponse.Face.Detect?
     ) {
         let subpath = imagePath
             .substring(
@@ -60,7 +63,7 @@ class PerseCameraViewController:
         }
 
         self.faceImageView.image = image
-        let face: FaceResponse = detectResponse.faces[0]
+        let face: PerseAPIResponse.Face.Face = detectResponse.faces[0]
         
         self.setSpoofingValidation(valid: face.livenessScore >= detectResponse.defaultThresholds.liveness)
         self.faceUnderexposeIcon.validate(valid: face.faceMetrics.underexposure > detectResponse.defaultThresholds.underexposure)

--- a/Example/PerseDemo/PerseDemo/PerseCameraViewController.swift
+++ b/Example/PerseDemo/PerseDemo/PerseCameraViewController.swift
@@ -15,9 +15,9 @@ class PerseCameraViewController:
     @IBOutlet var horizontalMovementLabel: UILabel!
     @IBOutlet var verticalMovementLabel: UILabel!
     @IBOutlet var tiltMovementLabel: UILabel!
-    @IBOutlet var faceUnderexposeIcon: UIImageView!
+    @IBOutlet var faceUnderexposureIcon: UIImageView!
     @IBOutlet var faceSharpnessIcon: UIImageView!
-    @IBOutlet var imageUnderexposeIcon: UIImageView!
+    @IBOutlet var imageUnderexposureIcon: UIImageView!
     @IBOutlet var imageSharpnessIcon: UIImageView!
     var image: UIImage?
         
@@ -66,9 +66,9 @@ class PerseCameraViewController:
         let face: PerseAPIResponse.Face.Face = detectResponse.faces[0]
         
         self.setSpoofingValidation(valid: face.livenessScore >= detectResponse.defaultThresholds.liveness)
-        self.faceUnderexposeIcon.validate(valid: face.faceMetrics.underexposure > detectResponse.defaultThresholds.underexposure)
+        self.faceUnderexposureIcon.validate(valid: face.faceMetrics.underexposure > detectResponse.defaultThresholds.underexposure)
         self.faceSharpnessIcon.validate(valid: face.faceMetrics.sharpness < detectResponse.defaultThresholds.sharpness)
-        self.imageUnderexposeIcon.validate(valid: detectResponse.imageMetrics.underexposure > detectResponse.defaultThresholds.underexposure)
+        self.imageUnderexposureIcon.validate(valid: detectResponse.imageMetrics.underexposure > detectResponse.defaultThresholds.underexposure)
         self.imageSharpnessIcon.validate(valid: detectResponse.imageMetrics.sharpness < detectResponse.defaultThresholds.sharpness)
     }
     
@@ -193,9 +193,9 @@ class PerseCameraViewController:
         self.horizontalMovementLabel.text = "-"
         self.verticalMovementLabel.text = "-"
         self.tiltMovementLabel.text = "-"
-        self.faceUnderexposeIcon.reset()
+        self.faceUnderexposureIcon.reset()
         self.faceSharpnessIcon.reset()
-        self.imageUnderexposeIcon.reset()
+        self.imageUnderexposureIcon.reset()
         self.imageSharpnessIcon.reset()
         self.perseCamera.setDetectionBoxColor(0, 1, 1, 1)
         self.perseCamera.setFaceContoursColor(0, 1, 1, 1)

--- a/Example/PerseDemo/PerseDemo/PerseDetectViewController.swift
+++ b/Example/PerseDemo/PerseDemo/PerseDetectViewController.swift
@@ -115,7 +115,7 @@ class PerseDetectViewController:
                 detectResponse.totalFaces
             ))
 
-            guard let faces = detectResponse.faces as Array<FaceResponse>? else {
+            guard let faces = detectResponse.faces as Array<PerseAPIResponse.Face.Face>? else {
                 return
             }
 

--- a/Example/PerseDemo/PerseDemoTests/DataUtils.swift
+++ b/Example/PerseDemo/PerseDemoTests/DataUtils.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 func getTempData(name: String) -> Data? {
-    guard let fileUrl: URL = Bundle(for: PerseFaceDetectWithDataTests.self)
+    guard let fileUrl: URL = Bundle(for: FaceDetectWithDataTests.self)
         .url(
             forResource: name,
             withExtension: "jpeg"

--- a/Example/PerseDemo/PerseDemoTests/FaceCompareWithDataTests.swift
+++ b/Example/PerseDemo/PerseDemoTests/FaceCompareWithDataTests.swift
@@ -3,9 +3,9 @@ import Perse
 import PerseLite
 import Foundation
 
-class PerseFaceCompareWithDataTests: XCTestCase {
-    
-    func testWithSameHuman() {
+class FaceCompareWithDataTests: XCTestCase {
+
+    func test_with_same_human() {
         compareWithData(
             self,
             firstImageName: "human",
@@ -13,13 +13,16 @@ class PerseFaceCompareWithDataTests: XCTestCase {
             apiKey: Environment.apiKey
         ) { response in
             XCTAssertEqual(response.status, 200)
-            XCTAssertGreaterThan(response.similarity, response.defaultThresholds.similarity)
+            XCTAssertGreaterThan(
+                response.similarity,
+                response.defaultThresholds.similarity
+            )
         } onError: { error in
             XCTFail("Error on compare: \(error)")
         }
     }
-    
-    func testWithDifferentHumans() {
+
+    func test_with_different_humans() {
         compareWithData(
             self,
             firstImageName: "human1",
@@ -27,13 +30,16 @@ class PerseFaceCompareWithDataTests: XCTestCase {
             apiKey: Environment.apiKey
         ) { response in
             XCTAssertEqual(response.status, 200)
-            XCTAssertLessThan(response.similarity, response.defaultThresholds.similarity)
+            XCTAssertLessThan(
+                response.similarity,
+                response.defaultThresholds.similarity
+            )
         } onError: { error in
             XCTFail("Error on compare: \(error)")
         }
     }
-    
-    func testWithHumanAndNonHuman() {
+
+    func test_with_human_and_non_human() {
         compareWithData(
             self,
             firstImageName: "human",
@@ -45,8 +51,8 @@ class PerseFaceCompareWithDataTests: XCTestCase {
             XCTAssertEqual(error, "402")
         }
     }
-    
-    func testWithNonHumanAndHuman() {
+
+    func test_with_non_human_and_human() {
         compareWithData(
             self,
             firstImageName: "dog",
@@ -58,8 +64,8 @@ class PerseFaceCompareWithDataTests: XCTestCase {
             XCTAssertEqual(error, "402")
         }
     }
-    
-    func testWithNonHumanAndNonHuman() {
+
+    func test_with_non_human_and_non_human() {
         compareWithData(
             self,
             firstImageName: "dog",
@@ -71,21 +77,8 @@ class PerseFaceCompareWithDataTests: XCTestCase {
             XCTAssertEqual(error, "402")
         }
     }
-    
-    func testWithAPIKeyInvalid() {
-        compareWithData(
-            self,
-            firstImageName: "human",
-            secondImageName: "human2",
-            apiKey: ""
-        ) { detectResponse in
-            XCTFail("Back-end authorized invalid api token.")
-        } onError: { error in
-            XCTAssertEqual(error, "401")
-        }
-    }
-        
-    func testWithImagePathsInvalid() {
+
+    func test_with_image_paths_invalid() {
         compareWithData(
             self,
             firstImageName: "test0",
@@ -94,11 +87,14 @@ class PerseFaceCompareWithDataTests: XCTestCase {
         ) { detectResponse in
             XCTFail("")
         } onError: { error in
-            XCTAssertEqual(error, Perse.Error.INVALID_IMAGE_PATH)
+            XCTAssertEqual(
+                error,
+                PerseLite.Error.INVALID_IMAGE_PATH
+            )
         }
     }
-    
-    func testWithNonHumans() {
+
+    func test_with_non_humans() {
         compareWithData(
             self,
             firstImageName: "dog",
@@ -110,5 +106,5 @@ class PerseFaceCompareWithDataTests: XCTestCase {
             XCTAssertEqual(error, "402")
         }
     }
-    
+
 }

--- a/Example/PerseDemo/PerseDemoTests/FaceCompareWithFileTests.swift
+++ b/Example/PerseDemo/PerseDemoTests/FaceCompareWithFileTests.swift
@@ -3,9 +3,9 @@ import Perse
 import PerseLite
 import Foundation
 
-class PerseFaceCompareWithFileTests: XCTestCase {
-    
-    func testWithSameHuman() {
+class FaceCompareWithFileTests: XCTestCase {
+
+    func test_with_same_human() {
         compareWithFile(
             self,
             firstImageName: "human",
@@ -13,13 +13,16 @@ class PerseFaceCompareWithFileTests: XCTestCase {
             apiKey: Environment.apiKey
         ) { response in
             XCTAssertEqual(response.status, 200)
-            XCTAssertGreaterThan(response.similarity, response.defaultThresholds.similarity)
+            XCTAssertGreaterThan(
+                response.similarity,
+                response.defaultThresholds.similarity
+            )
         } onError: { error in
             XCTFail("Error on compare: \(error)")
         }
     }
-    
-    func testWithDifferentHumans() {
+
+    func test_with_different_humans() {
         compareWithFile(
             self,
             firstImageName: "human1",
@@ -27,13 +30,16 @@ class PerseFaceCompareWithFileTests: XCTestCase {
             apiKey: Environment.apiKey
         ) { response in
             XCTAssertEqual(response.status, 200)
-            XCTAssertLessThan(response.similarity, response.defaultThresholds.similarity)
+            XCTAssertLessThan(
+                response.similarity,
+                response.defaultThresholds.similarity
+            )
         } onError: { error in
             XCTFail("Error on compare: \(error)")
         }
     }
-    
-    func testWithHumanAndNonHuman() {
+
+    func test_with_human_and_non_human() {
         compareWithFile(
             self,
             firstImageName: "human",
@@ -45,8 +51,8 @@ class PerseFaceCompareWithFileTests: XCTestCase {
             XCTAssertEqual(error, "402")
         }
     }
-    
-    func testWithNonHumanAndHuman() {
+
+    func test_with_non_human_and_human() {
         compareWithFile(
             self,
             firstImageName: "dog",
@@ -58,8 +64,8 @@ class PerseFaceCompareWithFileTests: XCTestCase {
             XCTAssertEqual(error, "402")
         }
     }
-    
-    func testWithNonHumanAndNonHuman() {
+
+    func test_with_non_human_and_non_human() {
         compareWithFile(
             self,
             firstImageName: "dog",
@@ -71,21 +77,8 @@ class PerseFaceCompareWithFileTests: XCTestCase {
             XCTAssertEqual(error, "402")
         }
     }
-    
-    func testWithAPIKeyInvalid() {
-        compareWithFile(
-            self,
-            firstImageName: "human",
-            secondImageName: "human2",
-            apiKey: ""
-        ) { detectResponse in
-            XCTFail("Back-end authorized invalid api token.")
-        } onError: { error in
-            XCTAssertEqual(error, "401")
-        }
-    }
-        
-    func testWithImagePathsInvalid() {
+
+    func test_with_image_paths_invalid() {
         compareWithFile(
             self,
             firstImageName: "test0",
@@ -94,11 +87,14 @@ class PerseFaceCompareWithFileTests: XCTestCase {
         ) { detectResponse in
             XCTFail("")
         } onError: { error in
-            XCTAssertEqual(error, Perse.Error.INVALID_IMAGE_PATH)
+            XCTAssertEqual(
+                error,
+                PerseLite.Error.INVALID_IMAGE_PATH
+            )
         }
     }
-    
-    func testWithNonHumans() {
+
+    func test_with_non_humans() {
         compareWithFile(
             self,
             firstImageName: "dog",
@@ -110,5 +106,5 @@ class PerseFaceCompareWithFileTests: XCTestCase {
             XCTAssertEqual(error, "402")
         }
     }
-    
+
 }

--- a/Example/PerseDemo/PerseDemoTests/FaceDetectWithDataTests.swift
+++ b/Example/PerseDemo/PerseDemoTests/FaceDetectWithDataTests.swift
@@ -3,10 +3,10 @@ import Perse
 import PerseLite
 import Foundation
 
-class PerseFaceDetectWithFileTests: XCTestCase {
-    
-    func testWithHuman() {
-        detectWithFile(
+class FaceDetectWithDataTests: XCTestCase {
+
+    func test_with_human() {
+        detectWithData(
             self,
             imageName: "human",
             apiKey: Environment.apiKey
@@ -16,9 +16,9 @@ class PerseFaceDetectWithFileTests: XCTestCase {
             XCTFail("Error on detect: \(error)")
         }
     }
-    
-    func testWithNonHuman() {
-        detectWithFile(
+
+    func test_with_non_human() {
+        detectWithData(
             self,
             imageName: "dog",
             apiKey: Environment.apiKey
@@ -28,28 +28,19 @@ class PerseFaceDetectWithFileTests: XCTestCase {
             XCTFail("Error on detect: \(error)")
         }
     }
-    
-    func testWithAPIKeyInvalid() {
-        detectWithFile(
-            self,
-            imageName: "human",
-            apiKey: ""
-        ) { detectResponse in
-            XCTFail("Back-end authorized invalid api token.")
-        } onError: { error in
-            XCTAssertEqual(error, "401")
-        }
-    }
-        
-    func testWithImagePathInvalid() {
-        detectWithFile(
+
+    func test_with_image_path_invalid() {
+        detectWithData(
             self,
             imageName: "test",
             apiKey: Environment.apiKey
         ) { detectResponse in
             XCTFail("")
         } onError: { error in
-            XCTAssertEqual(error, Perse.Error.INVALID_IMAGE_PATH)
+            XCTAssertEqual(
+                error,
+                PerseLite.Error.INVALID_IMAGE_PATH
+            )
         }
     }
 }

--- a/Example/PerseDemo/PerseDemoTests/FaceDetectWithFileTests.swift
+++ b/Example/PerseDemo/PerseDemoTests/FaceDetectWithFileTests.swift
@@ -3,10 +3,10 @@ import Perse
 import PerseLite
 import Foundation
 
-class PerseFaceDetectWithDataTests: XCTestCase {
-    
-    func testWithHuman() {
-        detectWithData(
+class FaceDetectWithFileTests: XCTestCase {
+
+    func test_with_human() {
+        detectWithFile(
             self,
             imageName: "human",
             apiKey: Environment.apiKey
@@ -16,9 +16,9 @@ class PerseFaceDetectWithDataTests: XCTestCase {
             XCTFail("Error on detect: \(error)")
         }
     }
-    
-    func testWithNonHuman() {
-        detectWithData(
+
+    func test_with_non_human() {
+        detectWithFile(
             self,
             imageName: "dog",
             apiKey: Environment.apiKey
@@ -28,28 +28,16 @@ class PerseFaceDetectWithDataTests: XCTestCase {
             XCTFail("Error on detect: \(error)")
         }
     }
-    
-    func testWithAPIKeyInvalid() {
-        detectWithData(
-            self,
-            imageName: "human",
-            apiKey: ""
-        ) { detectResponse in
-            XCTFail("Back-end authorized invalid api token.")
-        } onError: { error in
-            XCTAssertEqual(error, "401")
-        }
-    }
-        
-    func testWithImagePathInvalid() {
-        detectWithData(
+
+    func test_with_image_path_invalid() {
+        detectWithFile(
             self,
             imageName: "test",
             apiKey: Environment.apiKey
         ) { detectResponse in
             XCTFail("")
         } onError: { error in
-            XCTAssertEqual(error, Perse.Error.INVALID_IMAGE_PATH)
+            XCTAssertEqual(error, PerseLite.Error.INVALID_IMAGE_PATH)
         }
     }
 }

--- a/Example/PerseDemo/PerseDemoTests/FaceEnrollmentTests.swift
+++ b/Example/PerseDemo/PerseDemoTests/FaceEnrollmentTests.swift
@@ -1,0 +1,8 @@
+//
+//  FaceEnrollmentTests.swift
+//  PerseDemoTests
+//
+//  Created by Haroldo Shigueaki Teruya on 26/08/21.
+//
+
+import Foundation

--- a/Example/PerseDemo/PerseDemoTests/FaceEnrollmentTests.swift
+++ b/Example/PerseDemo/PerseDemoTests/FaceEnrollmentTests.swift
@@ -1,8 +1,42 @@
-//
-//  FaceEnrollmentTests.swift
-//  PerseDemoTests
-//
-//  Created by Haroldo Shigueaki Teruya on 26/08/21.
-//
-
+import XCTest
+import Perse
+import PerseLite
 import Foundation
+
+class FaceEnrollmentTests: XCTestCase {
+
+    func test_enrollment_face_create_and_delete() {
+        var userToken: String? = nil
+        
+        faceCreate(
+            self,
+            imageName: "human",
+            apiKey: Environment.apiKey
+        ) { response in
+            userToken = response.userToken
+            debugPrint("Created user token: " + userToken!)
+        } onError: { error in
+            XCTFail("Error on face create: \(error)")
+        }
+        
+        faceRead(
+            self,
+            apiKey: Environment.apiKey
+        ) { response in
+            debugPrint("Read user tokens: \(response.totalUsers)")
+        } onError: { error in
+            XCTFail("Error on face read: \(error)")
+        }
+        
+        faceDelete(
+            self,
+            userToken: userToken!,
+            apiKey: Environment.apiKey
+        ) { response in
+            debugPrint("Delete status: \(response.status)")
+            XCTAssertEqual(response.status, 200)
+        } onError: { error in
+            XCTFail("Error on face read: \(error)")
+        }
+    }
+}

--- a/Example/PerseDemo/PerseDemoTests/FileUtils.swift
+++ b/Example/PerseDemo/PerseDemoTests/FileUtils.swift
@@ -6,7 +6,7 @@ enum FileUtilsError: Error {
 }
 
 func getTempFilePath(name: String) -> String? {
-    guard let fileUrl: URL = Bundle(for: PerseFaceDetectWithFileTests.self)
+    guard let fileUrl: URL = Bundle(for: FaceDetectWithDataTests.self)
         .url(
             forResource: name,
             withExtension: "jpeg"

--- a/Example/PerseDemo/PerseDemoTests/PerseUtils.swift
+++ b/Example/PerseDemo/PerseDemoTests/PerseUtils.swift
@@ -7,18 +7,18 @@ public func detectWithFile(
     _ xctest: XCTestCase,
     imageName: String,
     apiKey: String,
-    onSuccess: @escaping (DetectResponse) -> Void,
+    onSuccess: @escaping (PerseAPIResponse.Face.Detect) -> Void,
     onError: @escaping (String) -> Void
 ) {
     let expectation = XCTestExpectation(description: "Perse face detect in a image.")
-    
+
     // Create a temp file image path from a resource.
     guard let tempFilePath: String = getTempFilePath(name: imageName) else {
         onError(Perse.Error.INVALID_IMAGE_PATH)
         expectation.fulfill()
         return
     }
-            
+
     // Start the face detect process.
     Perse(apiKey: apiKey, baseUrl: Environment.baseUrl)
         .face
@@ -34,7 +34,7 @@ public func detectWithFile(
         expectation.fulfill()
         return
     }
-    
+
     // Wait until the expectation is fulfilled, with a timeout of 10 seconds.
     xctest.wait(for: [expectation], timeout: 10.0)
 }
@@ -43,18 +43,18 @@ public func detectWithData(
     _ xctest: XCTestCase,
     imageName: String,
     apiKey: String,
-    onSuccess: @escaping (DetectResponse) -> Void,
+    onSuccess: @escaping (PerseAPIResponse.Face.Detect) -> Void,
     onError: @escaping (String) -> Void
 ) {
     let expectation = XCTestExpectation(description: "Perse face detect in a image.")
-    
+
     // Get a temp data from a resource.
     guard let data: Data = getTempData(name: imageName) else {
         onError(Perse.Error.INVALID_IMAGE_PATH)
         expectation.fulfill()
         return
     }
-            
+    
     // Start the face detect process.
     Perse(apiKey: apiKey, baseUrl: Environment.baseUrl)
         .face
@@ -70,7 +70,7 @@ public func detectWithData(
         expectation.fulfill()
         return
     }
-    
+
     // Wait until the expectation is fulfilled, with a timeout of 10 seconds.
     xctest.wait(for: [expectation], timeout: 10.0)
 }
@@ -79,26 +79,26 @@ public func compareWithFile(
     _ xctest: XCTestCase,
     firstImageName: String,
     secondImageName: String,
-    apiKey: String,    
-    onSuccess: @escaping (CompareResponse) -> Void,
+    apiKey: String,
+    onSuccess: @escaping (PerseAPIResponse.Face.Compare) -> Void,
     onError: @escaping (String) -> Void
 ) {
     let expectation = XCTestExpectation(description: "Perse face compare.")
-    
+
     // Create a temp file image path from a resource.
     guard let firstTempFilePath: String = getTempFilePath(name: firstImageName) else {
         onError(Perse.Error.INVALID_IMAGE_PATH)
         expectation.fulfill()
         return
     }
-    
+
     // Create a temp file image path from a resource.
     guard let secondTempFilePath: String = getTempFilePath(name: secondImageName) else {
         onError(Perse.Error.INVALID_IMAGE_PATH)
         expectation.fulfill()
         return
     }
-            
+
     // Start the face detect process.
     Perse(apiKey: apiKey, baseUrl: Environment.baseUrl)
         .face
@@ -116,7 +116,7 @@ public func compareWithFile(
         expectation.fulfill()
         return
     }
-    
+
     // Wait until the expectation is fulfilled, with a timeout of 10 seconds.
     xctest.wait(for: [expectation], timeout: 10.0)
 }
@@ -126,25 +126,25 @@ public func compareWithData(
     firstImageName: String,
     secondImageName: String,
     apiKey: String,
-    onSuccess: @escaping (CompareResponse) -> Void,
+    onSuccess: @escaping (PerseAPIResponse.Face.Compare) -> Void,
     onError: @escaping (String) -> Void
 ) {
     let expectation = XCTestExpectation(description: "Perse face compare.")
-    
+
     // Get data from file image path from a resource.
     guard let firstData: Data = getTempData(name: firstImageName) else {
         onError(Perse.Error.INVALID_IMAGE_PATH)
         expectation.fulfill()
         return
     }
-    
+
     // Get data from file image path from a resource.
     guard let secondData: Data = getTempData(name: secondImageName) else {
         onError(Perse.Error.INVALID_IMAGE_PATH)
         expectation.fulfill()
         return
     }
-            
+
     // Start the face detect process.
     Perse(apiKey: apiKey, baseUrl: Environment.baseUrl)
         .face
@@ -162,7 +162,109 @@ public func compareWithData(
         expectation.fulfill()
         return
     }
+
+    // Wait until the expectation is fulfilled, with a timeout of 10 seconds.
+    xctest.wait(for: [expectation], timeout: 10.0)
+}
+
+public func faceCreate(
+    _ xctest: XCTestCase,
+    imageName: String,
+    apiKey: String,
+    onSuccess: @escaping (PerseAPIResponse.Enrollment.Face.Create) -> Void,
+    onError: @escaping (String) -> Void
+) {
+    let expectation = XCTestExpectation(description: "Perse face create.")
+
+    // Get a temp data from a resource.
+    guard let data: Data = getTempData(name: imageName) else {
+        onError(Perse.Error.INVALID_IMAGE_PATH)
+        expectation.fulfill()
+        return
+    }
     
+    // Start the face detect process.
+    Perse(
+        apiKey: apiKey,
+        baseUrl: Environment.baseUrl
+    )
+        .face
+        .enrollment
+        .create(data)
+    {
+        response in
+        onSuccess(response)
+        expectation.fulfill()
+        return
+    } onError: {
+        status, error in
+        onError(status)
+        expectation.fulfill()
+        return
+    }
+
+    // Wait until the expectation is fulfilled, with a timeout of 10 seconds.
+    xctest.wait(for: [expectation], timeout: 10.0)
+}
+
+public func faceRead(
+    _ xctest: XCTestCase,
+    apiKey: String,
+    onSuccess: @escaping (PerseAPIResponse.Enrollment.Face.Read) -> Void,
+    onError: @escaping (String) -> Void
+) {
+    let expectation = XCTestExpectation(description: "Perse face read.")
+
+    // Start the face detect process.
+    Perse(apiKey: apiKey, baseUrl: Environment.baseUrl)
+        .face
+        .enrollment
+        .read()
+    {
+        response in
+        onSuccess(response)
+        expectation.fulfill()
+        return
+    } onError: {
+        status, error in
+        onError(status)
+        expectation.fulfill()
+        return
+    }
+
+    // Wait until the expectation is fulfilled, with a timeout of 10 seconds.
+    xctest.wait(for: [expectation], timeout: 10.0)
+}
+
+public func faceDelete(
+    _ xctest: XCTestCase,
+    userToken: String,
+    apiKey: String,
+    onSuccess: @escaping (PerseAPIResponse.Enrollment.Face.Delete) -> Void,
+    onError: @escaping (String) -> Void
+) {
+    let expectation = XCTestExpectation(description: "Perse face delete.")
+    
+    // Start the face detect process.
+    Perse(
+        apiKey: apiKey,
+        baseUrl: Environment.baseUrl
+    )
+        .face
+        .enrollment
+        .delete(userToken)
+    {
+        response in
+        onSuccess(response)
+        expectation.fulfill()
+        return
+    } onError: {
+        status, error in
+        onError(status)
+        expectation.fulfill()
+        return
+    }
+
     // Wait until the expectation is fulfilled, with a timeout of 10 seconds.
     xctest.wait(for: [expectation], timeout: 10.0)
 }

--- a/Example/PerseDemo/PerseDemoTests/PerseUtils.swift
+++ b/Example/PerseDemo/PerseDemoTests/PerseUtils.swift
@@ -171,7 +171,7 @@ public func faceCreate(
     _ xctest: XCTestCase,
     imageName: String,
     apiKey: String,
-    onSuccess: @escaping (PerseAPIResponse.Enrollment.Face.Create) -> Void,
+    onSuccess: @escaping (PerseAPIResponse.Face.Enrollment.Create) -> Void,
     onError: @escaping (String) -> Void
 ) {
     let expectation = XCTestExpectation(description: "Perse face create.")
@@ -210,7 +210,7 @@ public func faceCreate(
 public func faceRead(
     _ xctest: XCTestCase,
     apiKey: String,
-    onSuccess: @escaping (PerseAPIResponse.Enrollment.Face.Read) -> Void,
+    onSuccess: @escaping (PerseAPIResponse.Face.Enrollment.Read) -> Void,
     onError: @escaping (String) -> Void
 ) {
     let expectation = XCTestExpectation(description: "Perse face read.")
@@ -240,7 +240,7 @@ public func faceDelete(
     _ xctest: XCTestCase,
     userToken: String,
     apiKey: String,
-    onSuccess: @escaping (PerseAPIResponse.Enrollment.Face.Delete) -> Void,
+    onSuccess: @escaping (PerseAPIResponse.Face.Enrollment.Delete) -> Void,
     onError: @escaping (String) -> Void
 ) {
     let expectation = XCTestExpectation(description: "Perse face delete.")

--- a/Example/PerseDemo/Podfile
+++ b/Example/PerseDemo/Podfile
@@ -3,7 +3,6 @@
 
 target 'PerseDemo' do
   # Comment the next line if you don't want to use dynamic frameworks
-  # use_frameworks!
   
   # Pods for PerseDemo
   pod 'Perse', :path => '../../'

--- a/Example/PerseDemo/Podfile.lock
+++ b/Example/PerseDemo/Podfile.lock
@@ -4,11 +4,11 @@ PODS:
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleMLKit/FaceDetection (2.2.0):
+  - GoogleMLKit/FaceDetection (2.3.0):
     - GoogleMLKit/MLKitCore
     - MLKitFaceDetection (~> 1.3.0)
-  - GoogleMLKit/MLKitCore (2.2.0):
-    - MLKitCommon (~> 3.0.0)
+  - GoogleMLKit/MLKitCore (2.3.0):
+    - MLKitCommon (~> 3.1.0)
   - GoogleToolboxForMac/DebugUtils (2.3.2):
     - GoogleToolboxForMac/Defines (= 2.3.2)
   - GoogleToolboxForMac/Defines (2.3.2)
@@ -21,17 +21,17 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.3.2)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.3.2)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.3.2)"
-  - GoogleUtilities/Environment (7.5.0):
+  - GoogleUtilities/Environment (7.5.1):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.5.0):
+  - GoogleUtilities/Logger (7.5.1):
     - GoogleUtilities/Environment
-  - GoogleUtilities/UserDefaults (7.5.0):
+  - GoogleUtilities/UserDefaults (7.5.1):
     - GoogleUtilities/Logger
   - GoogleUtilitiesComponents (1.0.0):
     - GoogleUtilities/Logger
   - GTMSessionFetcher/Core (1.6.1)
   - MLImage (1.0.0-beta1)
-  - MLKitCommon (3.0.0):
+  - MLKitCommon (3.1.0):
     - GoogleDataTransport (~> 9.0)
     - GoogleToolboxForMac/Logger (~> 2.1)
     - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
@@ -55,11 +55,11 @@ PODS:
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
-  - Perse (0.1.0):
+  - Perse (0.2.0):
     - Alamofire (~> 5.2)
     - PerseLite (~> 0.2.0)
     - YoonitCamera
-  - PerseLite (0.2.0):
+  - PerseLite (0.2.1):
     - Alamofire (~> 5.2)
   - PromisesObjC (2.0.0)
   - Protobuf (3.17.0)
@@ -98,23 +98,23 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Alamofire: e447a2774a40c996748296fa2c55112fdbbc42f9
   GoogleDataTransport: 85fd18ff3019bb85d3f2c551d04c481dedf71fc9
-  GoogleMLKit: 85ffdc9641d05311c76dbba5bbf93059087be12f
+  GoogleMLKit: 53d5adbee0fe5a701e970f1387d2cfececd5bc50
   GoogleToolboxForMac: 8bef7c7c5cf7291c687cf5354f39f9db6399ad34
-  GoogleUtilities: eea970f4a389963963bffe8d8fabe43540678b9c
+  GoogleUtilities: 3df19e3c24f7bbc291d8b5809aa6b0d41e642437
   GoogleUtilitiesComponents: a69c0b3b369ba443e988141e75ef49d9010b1c80
   GTMSessionFetcher: 36689134877faeb055b27dfa4ccc9ceaa42e029e
   MLImage: 647f3d580c10b3c9a3f6154f5d7baead60c42a0c
-  MLKitCommon: 6d6be0a2e9a6340aad1c1f2b9449c11dee8af70f
+  MLKitCommon: 1b5c79d52f79d9cc93ab5300e9713c4c215121ea
   MLKitFaceDetection: 897f007aa4eb426ef1bac7c66e5451d02ffc2e83
   MLKitVision: 26da299aef93291f24f5200e8372919f73abf3b5
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  Perse: c7a90b8843d745ef827213e0cc1717a7e5604c91
-  PerseLite: 2287a9aebcc03672f5615c35a1ae0c1de3836a15
+  Perse: cdf0193ad6269bffd77343fc517ffbbd5c6dfbad
+  PerseLite: 2de2ecd713a7010a876b2648a109b3b0188ae54b
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Protobuf: 7327d4444215b5f18e560a97f879ff5503c4581c
   YoonitCamera: eacfd2924f0838f895e6617fcf668e52ada4717f
   YoonitFacefy: 2a583328b5cfd74a2bea98e416038091a8b1ec55
 
-PODFILE CHECKSUM: 0b2c9991c223ae5db48490edf6a5b626ab40b8aa
+PODFILE CHECKSUM: 7a42e7e3935ee42e8ea15b82499ad25a0a57b28b
 
 COCOAPODS: 1.10.1

--- a/Example/PerseDemo/Podfile.lock
+++ b/Example/PerseDemo/Podfile.lock
@@ -57,9 +57,9 @@ PODS:
   - nanopb/encode (2.30908.0)
   - Perse (0.2.0):
     - Alamofire (~> 5.2)
-    - PerseLite (~> 0.2.0)
+    - PerseLite (~> 0.3.1)
     - YoonitCamera
-  - PerseLite (0.2.1):
+  - PerseLite (0.3.1):
     - Alamofire (~> 5.2)
   - PromisesObjC (2.0.0)
   - Protobuf (3.17.0)
@@ -108,8 +108,8 @@ SPEC CHECKSUMS:
   MLKitFaceDetection: 897f007aa4eb426ef1bac7c66e5451d02ffc2e83
   MLKitVision: 26da299aef93291f24f5200e8372919f73abf3b5
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  Perse: cdf0193ad6269bffd77343fc517ffbbd5c6dfbad
-  PerseLite: 2de2ecd713a7010a876b2648a109b3b0188ae54b
+  Perse: f72309d5d7c0e762699ea585ef34b742ebd69272
+  PerseLite: 3a81800c4ab26d4dea3b17a73cfa593fb0506e52
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Protobuf: 7327d4444215b5f18e560a97f879ff5503c4581c
   YoonitCamera: eacfd2924f0838f895e6617fcf668e52ada4717f

--- a/Perse.podspec
+++ b/Perse.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |spec|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 
   spec.name         = "Perse"
-  spec.version      = "0.1.2"
+  spec.version      = "0.2.0"
   spec.summary      = "Perse SDK iOS"
   spec.description  = <<-DESC
     "This SDK provides camera integration and abstracts the communication with the Perse's API endpoints and also convert the response from json to a pre-defined responses."
@@ -30,7 +30,7 @@ Pod::Spec.new do |spec|
   spec.source_files  = "Perse/src/**/*", "Classes", "Classes/**/*.{h,m,swift}"
   spec.exclude_files = "Classes/Exclude"
   spec.dependency 'Alamofire', '~> 5.2'
-  spec.dependency 'PerseLite', '~> 0.2.0'
+  spec.dependency 'PerseLite', '~> 0.3.0'
   spec.dependency 'YoonitCamera'
   
   spec.static_framework = true

--- a/Perse.podspec
+++ b/Perse.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |spec|
   spec.source_files  = "Perse/src/**/*", "Classes", "Classes/**/*.{h,m,swift}"
   spec.exclude_files = "Classes/Exclude"
   spec.dependency 'Alamofire', '~> 5.2'
-  spec.dependency 'PerseLite', '~> 0.3.0'
+  spec.dependency 'PerseLite', '~> 0.3.1'
   spec.dependency 'YoonitCamera'
   
   spec.static_framework = true

--- a/Perse.xcodeproj/project.pbxproj
+++ b/Perse.xcodeproj/project.pbxproj
@@ -460,7 +460,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.2;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.cyberlabs.perse;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/Perse.xcodeproj/project.pbxproj
+++ b/Perse.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1034214408861265D314CA50 /* Pods_Perse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1662896A8F60C015743C9E8F /* Pods_Perse.framework */; };
 		5C03EE82269C8D7800143FE1 /* Perse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C03EE81269C8D7800143FE1 /* Perse.swift */; };
 		5C06E5CF25D1FED400E6770F /* PerseCamera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C06E5CE25D1FED400E6770F /* PerseCamera.swift */; };
 		5C2FFC07266E5715000DD190 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 5C2FFC06266E5715000DD190 /* README.md */; };
@@ -22,11 +21,12 @@
 		5CCC92E826BC30C30016CCB3 /* testing_with_xcode.png in Resources */ = {isa = PBXBuildFile; fileRef = 5CCC92E526BC30C30016CCB3 /* testing_with_xcode.png */; };
 		5CCC93BC26BC3C190016CCB3 /* anti_spoof.gif in Resources */ = {isa = PBXBuildFile; fileRef = 5CCC93BB26BC3C190016CCB3 /* anti_spoof.gif */; };
 		6176EFA8252E476000F4D4DD /* Example in Resources */ = {isa = PBXBuildFile; fileRef = 6176EFA7252E476000F4D4DD /* Example */; };
+		F0DBE3230F3127C8A30A3B9A /* libPods-Perse.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 541F630D6EC3DD39296F3D9F /* libPods-Perse.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		1662896A8F60C015743C9E8F /* Pods_Perse.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Perse.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C42C24943CE9C527251E2AA /* Pods-Perse.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Perse.release.xcconfig"; path = "Target Support Files/Pods-Perse/Pods-Perse.release.xcconfig"; sourceTree = "<group>"; };
+		541F630D6EC3DD39296F3D9F /* libPods-Perse.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Perse.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5C03EE81269C8D7800143FE1 /* Perse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Perse.swift; sourceTree = "<group>"; };
 		5C06E5CE25D1FED400E6770F /* PerseCamera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerseCamera.swift; sourceTree = "<group>"; };
 		5C2FFC06266E5715000DD190 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -59,7 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1034214408861265D314CA50 /* Pods_Perse.framework in Frameworks */,
+				F0DBE3230F3127C8A30A3B9A /* libPods-Perse.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -142,7 +142,7 @@
 				5C65788725D32FB2001171F8 /* libnanopb.a */,
 				5C65788B25D32FB2001171F8 /* libPromisesObjC.a */,
 				5C65788D25D32FB2001171F8 /* libProtobuf.a */,
-				1662896A8F60C015743C9E8F /* Pods_Perse.framework */,
+				541F630D6EC3DD39296F3D9F /* libPods-Perse.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -430,7 +430,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.2;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.cyberlabs.perse;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/Perse.xcodeproj/project.pbxproj
+++ b/Perse.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2CD63165F30648A9CBA9800A /* libPods-Perse.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 77709D691A957EA04CE69A19 /* libPods-Perse.a */; };
 		5C03EE82269C8D7800143FE1 /* Perse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C03EE81269C8D7800143FE1 /* Perse.swift */; };
 		5C06E5CF25D1FED400E6770F /* PerseCamera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C06E5CE25D1FED400E6770F /* PerseCamera.swift */; };
 		5C2FFC07266E5715000DD190 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 5C2FFC06266E5715000DD190 /* README.md */; };
@@ -21,12 +22,9 @@
 		5CCC92E826BC30C30016CCB3 /* testing_with_xcode.png in Resources */ = {isa = PBXBuildFile; fileRef = 5CCC92E526BC30C30016CCB3 /* testing_with_xcode.png */; };
 		5CCC93BC26BC3C190016CCB3 /* anti_spoof.gif in Resources */ = {isa = PBXBuildFile; fileRef = 5CCC93BB26BC3C190016CCB3 /* anti_spoof.gif */; };
 		6176EFA8252E476000F4D4DD /* Example in Resources */ = {isa = PBXBuildFile; fileRef = 6176EFA7252E476000F4D4DD /* Example */; };
-		F0DBE3230F3127C8A30A3B9A /* libPods-Perse.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 541F630D6EC3DD39296F3D9F /* libPods-Perse.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		4C42C24943CE9C527251E2AA /* Pods-Perse.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Perse.release.xcconfig"; path = "Target Support Files/Pods-Perse/Pods-Perse.release.xcconfig"; sourceTree = "<group>"; };
-		541F630D6EC3DD39296F3D9F /* libPods-Perse.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Perse.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5C03EE81269C8D7800143FE1 /* Perse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Perse.swift; sourceTree = "<group>"; };
 		5C06E5CE25D1FED400E6770F /* PerseCamera.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerseCamera.swift; sourceTree = "<group>"; };
 		5C2FFC06266E5715000DD190 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -51,7 +49,9 @@
 		6176EEF6252CF9D200F4D4DD /* Perse.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Perse.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6176EEFA252CF9D200F4D4DD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6176EFA7252E476000F4D4DD /* Example */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Example; sourceTree = "<group>"; };
-		8D5E3759BFE5151D8390F41E /* Pods-Perse.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Perse.debug.xcconfig"; path = "Target Support Files/Pods-Perse/Pods-Perse.debug.xcconfig"; sourceTree = "<group>"; };
+		77709D691A957EA04CE69A19 /* libPods-Perse.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Perse.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9562F418EB30A305C7FBB73B /* Pods-Perse.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Perse.debug.xcconfig"; path = "Target Support Files/Pods-Perse/Pods-Perse.debug.xcconfig"; sourceTree = "<group>"; };
+		F3267C76ADD5C179B5D2DDD9 /* Pods-Perse.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Perse.release.xcconfig"; path = "Target Support Files/Pods-Perse/Pods-Perse.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,7 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F0DBE3230F3127C8A30A3B9A /* libPods-Perse.a in Frameworks */,
+				2CD63165F30648A9CBA9800A /* libPods-Perse.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,8 +125,8 @@
 		85073D94B694632C1A966E28 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				8D5E3759BFE5151D8390F41E /* Pods-Perse.debug.xcconfig */,
-				4C42C24943CE9C527251E2AA /* Pods-Perse.release.xcconfig */,
+				9562F418EB30A305C7FBB73B /* Pods-Perse.debug.xcconfig */,
+				F3267C76ADD5C179B5D2DDD9 /* Pods-Perse.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -142,7 +142,7 @@
 				5C65788725D32FB2001171F8 /* libnanopb.a */,
 				5C65788B25D32FB2001171F8 /* libPromisesObjC.a */,
 				5C65788D25D32FB2001171F8 /* libProtobuf.a */,
-				541F630D6EC3DD39296F3D9F /* libPods-Perse.a */,
+				77709D691A957EA04CE69A19 /* libPods-Perse.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -165,12 +165,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6176EEFE252CF9D200F4D4DD /* Build configuration list for PBXNativeTarget "Perse" */;
 			buildPhases = (
-				E49F627DD78F1EFA01675EB2 /* [CP] Check Pods Manifest.lock */,
+				2479D0282C0B5865695CA9D0 /* [CP] Check Pods Manifest.lock */,
 				6176EEF1252CF9D200F4D4DD /* Headers */,
 				6176EEF2252CF9D200F4D4DD /* Sources */,
 				6176EEF3252CF9D200F4D4DD /* Frameworks */,
 				6176EEF4252CF9D200F4D4DD /* Resources */,
-				2DF08A2EC2E9F98580F6410A /* [CP] Copy Pods Resources */,
+				11EA33AAE2E5D9119B2F36E2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -233,7 +233,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2DF08A2EC2E9F98580F6410A /* [CP] Copy Pods Resources */ = {
+		11EA33AAE2E5D9119B2F36E2 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -250,7 +250,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Perse/Pods-Perse-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E49F627DD78F1EFA01675EB2 /* [CP] Check Pods Manifest.lock */ = {
+		2479D0282C0B5865695CA9D0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -413,7 +413,7 @@
 		};
 		6176EEFF252CF9D200F4D4DD /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8D5E3759BFE5151D8390F41E /* Pods-Perse.debug.xcconfig */;
+			baseConfigurationReference = 9562F418EB30A305C7FBB73B /* Pods-Perse.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -443,7 +443,7 @@
 		};
 		6176EF00252CF9D200F4D4DD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4C42C24943CE9C527251E2AA /* Pods-Perse.release.xcconfig */;
+			baseConfigurationReference = F3267C76ADD5C179B5D2DDD9 /* Pods-Perse.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/Perse/src/PerseCamera.swift
+++ b/Perse/src/PerseCamera.swift
@@ -12,22 +12,13 @@ import YoonitCamera
 import PerseLite
 
 /**
- CameraView component integrated with YoonitCamera and PerseLite.
+ CameraView component integrated with YoonitCamera and Perse.
  */
 @objc
 open class PerseCamera: CameraView, CameraEventListenerDelegate {
         
-    public var apiKey: String? = nil {
-        didSet {
-            if let apiKey = apiKey {
-                self.perseLite = PerseLite(apiKey: apiKey)
-            }
-        }
-    }
-        
     public var perseEventListener: PerseEventListener?
-    static var url: String = "https://api.stg.getperse.com/v0/"
-    public var perseLite: PerseLite?
+    public var perse: Perse?
 
     required public init?(coder: NSCoder) {
         super.init(coder: coder)
@@ -60,7 +51,7 @@ open class PerseCamera: CameraView, CameraEventListenerDelegate {
         _ sharpness: NSNumber?
     ) {
         if let perseEventListener = self.perseEventListener {
-            if self.apiKey == nil {
+            if self.perse == nil {
                 debugPrint(
                     "PerseCamera",
                     "No API Key set. To get a API Key: https://github.com/cyberlabsai/perse-sdk-ios/wiki/2.-API-Key."
@@ -74,7 +65,7 @@ open class PerseCamera: CameraView, CameraEventListenerDelegate {
                 return
             }
             
-            self.perseLite?.face.detect(imagePath) {
+            self.perse?.face.detect(imagePath) {
                 detectResponse in
                 
                 perseEventListener.onImageCaptured(

--- a/Perse/src/PerseEventListener.swift
+++ b/Perse/src/PerseEventListener.swift
@@ -19,7 +19,7 @@ public protocol PerseEventListener {
         _ count: Int,
         _ total: Int,
         _ imagePath: String,
-        _ detectResponse: DetectResponse?
+        _ detectResponse: PerseAPIResponse.Face.Detect?
     )
 
     func onFaceDetected(

--- a/Podfile
+++ b/Podfile
@@ -2,9 +2,8 @@
 
 target 'Perse' do
   # Comment the next line if you don't want to use dynamic frameworks
-  # use_frameworks!
-
+  
   # Pods for Perse
-  pod 'PerseLite', '~> 0.2.0'
+  pod 'PerseLite', '~> 0.3.0'
   pod 'YoonitCamera'
 end

--- a/Podfile
+++ b/Podfile
@@ -4,6 +4,6 @@ target 'Perse' do
   # Comment the next line if you don't want to use dynamic frameworks
   
   # Pods for Perse
-  pod 'PerseLite', '~> 0.3.0'
+  pod 'PerseLite', '~> 0.3.1'
   pod 'YoonitCamera'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -55,7 +55,7 @@ PODS:
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
-  - PerseLite (0.3.0):
+  - PerseLite (0.3.1):
     - Alamofire (~> 5.2)
   - PromisesObjC (2.0.0)
   - Protobuf (3.17.0)
@@ -65,7 +65,7 @@ PODS:
     - GoogleMLKit/FaceDetection
 
 DEPENDENCIES:
-  - PerseLite (from `../perse-sdk-lite-ios`)
+  - PerseLite (~> 0.3.1)
   - YoonitCamera
 
 SPEC REPOS:
@@ -82,14 +82,11 @@ SPEC REPOS:
     - MLKitFaceDetection
     - MLKitVision
     - nanopb
+    - PerseLite
     - PromisesObjC
     - Protobuf
     - YoonitCamera
     - YoonitFacefy
-
-EXTERNAL SOURCES:
-  PerseLite:
-    :path: "../perse-sdk-lite-ios"
 
 SPEC CHECKSUMS:
   Alamofire: e447a2774a40c996748296fa2c55112fdbbc42f9
@@ -104,12 +101,12 @@ SPEC CHECKSUMS:
   MLKitFaceDetection: 897f007aa4eb426ef1bac7c66e5451d02ffc2e83
   MLKitVision: 26da299aef93291f24f5200e8372919f73abf3b5
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  PerseLite: 5a89c7a3f5528651c7e421ff97932039e842a2d4
+  PerseLite: 3a81800c4ab26d4dea3b17a73cfa593fb0506e52
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Protobuf: 7327d4444215b5f18e560a97f879ff5503c4581c
   YoonitCamera: eacfd2924f0838f895e6617fcf668e52ada4717f
   YoonitFacefy: 2a583328b5cfd74a2bea98e416038091a8b1ec55
 
-PODFILE CHECKSUM: ce388eca205ff1a50bc0b5b3f292e372ad69241f
+PODFILE CHECKSUM: eba5e7eeb636315bc30867b9a9a0ee4e2ff3e573
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -55,7 +55,7 @@ PODS:
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
-  - PerseLite (0.2.0):
+  - PerseLite (0.3.0):
     - Alamofire (~> 5.2)
   - PromisesObjC (2.0.0)
   - Protobuf (3.17.0)
@@ -65,7 +65,7 @@ PODS:
     - GoogleMLKit/FaceDetection
 
 DEPENDENCIES:
-  - PerseLite (~> 0.2.0)
+  - PerseLite (from `../perse-sdk-lite-ios`)
   - YoonitCamera
 
 SPEC REPOS:
@@ -82,11 +82,14 @@ SPEC REPOS:
     - MLKitFaceDetection
     - MLKitVision
     - nanopb
-    - PerseLite
     - PromisesObjC
     - Protobuf
     - YoonitCamera
     - YoonitFacefy
+
+EXTERNAL SOURCES:
+  PerseLite:
+    :path: "../perse-sdk-lite-ios"
 
 SPEC CHECKSUMS:
   Alamofire: e447a2774a40c996748296fa2c55112fdbbc42f9
@@ -101,12 +104,12 @@ SPEC CHECKSUMS:
   MLKitFaceDetection: 897f007aa4eb426ef1bac7c66e5451d02ffc2e83
   MLKitVision: 26da299aef93291f24f5200e8372919f73abf3b5
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  PerseLite: 2287a9aebcc03672f5615c35a1ae0c1de3836a15
+  PerseLite: 5a89c7a3f5528651c7e421ff97932039e842a2d4
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Protobuf: 7327d4444215b5f18e560a97f879ff5503c4581c
   YoonitCamera: eacfd2924f0838f895e6617fcf668e52ada4717f
   YoonitFacefy: 2a583328b5cfd74a2bea98e416038091a8b1ec55
 
-PODFILE CHECKSUM: 9ace3a09aead93f680a1515667334bb5b5398e55
+PODFILE CHECKSUM: ce388eca205ff1a50bc0b5b3f292e372ad69241f
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
## 💥  Breaking Changes

Complete breaking changes in the [Responses](https://github.com/cyberlabsai/perse-sdk-ios/wiki/4.-API#responses), [Methods](https://github.com/cyberlabsai/perse-sdk-ios/wiki/4.-API#methods) and your usages. Motivations:
* Improve cohesion;
* Patterning with the [methods](https://github.com/cyberlabsai/perse-sdk-ios/wiki/4.-API#methods);
* Prepare for future features, like the "vox"s;

### API Responses

| Deprecated                     | New Usage
| -                                       | -
| `CompareResponse `    | `PerseAPIResponse.Face.Compare`
| `DetectResponse `        | `PerseAPIResponse.Face.Detect` 
| `FaceResponse `           | `PerseAPIResponse.Face.Face`
| `MetricsResponse `       | `PerseAPIResponse.Face.Metrics` 
| `LandmarksResponse ` | `PerseAPIResponse.Face.Landmarks` 

### Methods

| Deprecated | New 
| - | -
| `func detect( _ filePath: String, onSuccess: @escaping (DetectResponse) -> Void, onError: @escaping (String, String) -> Void)`| `func detect( _ filePath: String, onSuccess: @escaping (PerseAPIResponse.Face.Detect) -> Void, onError: @escaping (String, String) -> Void)`
| `func detect( _ data: Data, onSuccess: @escaping (DetectResponse) -> Void, onError: @escaping (String, String) -> Void)`| `func detect( _ data: Data, onSuccess: @escaping (PerseAPIResponse.Face.Detect) -> Void, onError: @escaping (String, String) -> Void)`
| `func compare( _ firstFilePath: String, _ secondFilePath: String, onSuccess: @escaping (CompareResponse) -> Void, onError: @escaping (String, String) -> Void)`| `func compare( _ firstFilePath: String, _ secondFilePath: String, onSuccess: @escaping (PerseAPIResponse.Face.Compare) -> Void, onError: @escaping (String, String) -> Void)`
| `func compare( _ firstData: Data, _ secondData: Data, onSuccess: @escaping (CompareResponse) -> Void, onError: @escaping (String, String) -> Void)`| `func compare(  _ firstData: Data, _ secondData: Data, onSuccess: @escaping (PerseAPIResponse.Face.Compare) -> Void, onError: @escaping (String, String) -> Void)`

## ✨  New Feature

### Face Enrollment

Enrolled faces are persisted and can be used for saving biometric facial features for future use. The enrollment's methods allow you to create, update, delete and get enrolled faces.

**face.enrollment.create**

* Responsible for creating new enrollment;
* Extract the facial features of the largest face;
* Faces that are not completely inside the image will not be considered;
* The input can be the image file path or his [Data](https://developer.apple.com/documentation/foundation/data);
* The `onSuccess` type is `PerseAPIResponse.Face.Enrollment.Create` struct;

```swift
func create(
    _ filePath: String,
    onSuccess: @escaping (PerseAPIResponse.Face.Enrollment.Create) -> Void,
    onError: @escaping (String, String) -> Void
)
```

```swift
func create(
    _ data: Data,
    onSuccess: @escaping (PerseAPIResponse.Face.Enrollment.Create) -> Void,
    onError: @escaping (String, String) -> Void
)
```

**face.enrollment.update**

* Responsible for update a face enrollment with a new face image and user token;
* Extract the facial features of the largest face;
* Faces that are not completely inside the image will not be considered;
* The input can be the image file path or his [Data](https://developer.apple.com/documentation/foundation/data);
* The `onSuccess` type is `PerseAPIResponse.Face.Enrollment.Update` struct;

```swift
func update(
    _ filePath: String,
    _ userToken: String,
    onSuccess: @escaping (PerseAPIResponse.Face.Enrollment.Update) -> Void,
    onError: @escaping (String, String) -> Void
)
```

```swift
func update(
    _ data: Data,
    _ userToken: String,
    onSuccess: @escaping (PerseAPIResponse.Face.Enrollment.Update) -> Void,
    onError: @escaping (String, String) -> Void
)
```

**face.enrollment.delete**

* Responsible for delete an enrollment;
* This endpoint expects a "user token" in the url;
* The `onSuccess` type is `PerseAPIResponse.Face.Enrollment.Delete` struct;

```swift
func delete(
    onSuccess: @escaping (PerseAPIResponse.Face.Enrollment.Delete) -> Void,
    onError: @escaping (String, String) -> Void
)
```

**face.enrollment.read**

* Responsible the complete list of the created "user tokens";
* The `onSuccess` type is `PerseAPIResponse.Face.Enrollment.Read` struct;

```swift
func read(
    onSuccess: @escaping (PerseAPIResponse.Face.Enrollment.Read) -> Void,
    onError: @escaping (String, String) -> Void
)
```

## 🐛  Bug Fix

Fix terms "underexpose" to "underexposure" in the Demo project.

## ⚡️  Improvements

Change the tests names to the camel case pattern for better reading. This changes has no impact in tests usage.